### PR TITLE
Fix incorrect directory permission and cleanup role

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,18 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("f", ["/var/cyhy/ncats-webui"])
-def test_files(host, f):
-    """Test that the expected files and directories are present."""
-    assert host.file(f).exists
+@pytest.mark.parametrize(
+    "directory", [{"mode": "0o750", "path": "/var/cyhy/ncats-webui"}]
+)
+def test_directories(host, directory):
+    """Test that the appropriate directories were created."""
+    assert host.file(directory["path"]).exists
+    assert host.file(directory["path"]).is_directory
+    assert oct(host.file(directory["path"]).mode) == directory["mode"]
+
+
+@pytest.mark.parametrize("file", [{"path": "/var/cyhy/ncats-webui/docker-compose.yml"}])
+def test_files(host, file):
+    """Test that the appropriate files were created."""
+    assert host.file(file["path"]).exists
+    assert host.file(file["path"]).is_file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     state: directory
     mode: 0760
 
-- name: Download and untar the webui tarball
+- name: Download and untar the ncats-webui tarball
   ansible.builtin.unarchive:
     src: https://api.github.com/repos/cisagov/ncats-webui/tarball/develop
     dest: /var/cyhy/ncats-webui

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   ansible.builtin.file:
     path: /var/cyhy/ncats-webui
     state: directory
-    mode: 0760
+    mode: 0750
 
 - name: Download and untar the ncats-webui tarball
   ansible.builtin.unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,14 +4,14 @@
 #
 - name: Create /var/cyhy/ncats-webui directory
   ansible.builtin.file:
+    mode: 0750
     path: /var/cyhy/ncats-webui
     state: directory
-    mode: 0750
 
 - name: Download and untar the ncats-webui tarball
   ansible.builtin.unarchive:
-    src: https://api.github.com/repos/cisagov/ncats-webui/tarball/develop
     dest: /var/cyhy/ncats-webui
-    remote_src: yes
     extra_opts:
       - --strip-components=1
+    remote_src: yes
+    src: https://api.github.com/repos/cisagov/ncats-webui/tarball/develop

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,8 @@
 
 - name: Download and untar the webui tarball
   ansible.builtin.unarchive:
-    src: "https://api.github.com/repos/cisagov/ncats-webui/tarball/develop"
+    src: https://api.github.com/repos/cisagov/ncats-webui/tarball/develop
     dest: /var/cyhy/ncats-webui
     remote_src: yes
     extra_opts:
-      - "--strip-components=1"
+      - --strip-components=1


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes an incorrect directory permission of `0760` to the correct `0750` and does some cleanup while we're here.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I noticed that I was having issues interacting with the `/var/cyhy` directory in my [CyHy](https://github.com/cisagov/cyhy_amis) test environment's `dashboard` instance. When I looked I saw that the directory had `0760` (read/write) permissions instead of the expected `0750` (read/execute) permissions. Tracking down where it was set to `0760` I found it here in this repository.

While I was here I thought I would do some small cleanup on the tasks file as a whole and I needed to update and extend the testing done in the [molecule](https://github.com/ansible-community/molecule) configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
